### PR TITLE
Update Hackers' Pub logo and categories

### DIFF
--- a/software.json
+++ b/software.json
@@ -1530,6 +1530,7 @@
         "name": "Hackers' Pub",
         "slug": "hackerspub",
         "categories": [
+            "blogging",
             "microblogging"
         ],
         "key_features": [],
@@ -1544,8 +1545,8 @@
         "forum_url": "https://github.com/hackers-pub/hackerspub/discussions",
         "donate_url": "https://github.com/sponsors/dahlia",
         "matrix_url": null,
-        "logo_source_url": null,
-        "logo_source_version": null
+        "logo_source_url": "https://rawcdn.githack.com/hackers-pub/visual-identity/f7995adf9e61a409ac11dde8502275f56e0f8ad4/exports/pubnyan-normal-border.svg",
+        "logo_source_version": 1
     },
     {
         "name": "frequency",


### PR DESCRIPTION
Since Hackers' Pub supports long-form writing as well, I added `blogging` to the `categories`. Also, added the Hackers' Pub official logo.