### PR TITLE
Add JFK Social software and app entries

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -637,5 +637,14 @@
         "os": ["android"],
         "url": "https://play.google.com/store/apps/details?id=com.pixelfed.loops&ref=fedidb.com",
         "createdAt": "June 2026"
+    },
+    {
+        "name": "JFK Social",
+        "description": "The official web app for JFK Social.",
+        "compatibility": ["JFK Social"],
+        "categories": ["official", "client"],
+        "os": ["web"],
+        "url": "https://jfksocial.com",
+        "createdAt": null
     }
 ]

--- a/software.json
+++ b/software.json
@@ -1739,7 +1739,7 @@
         "forum_url": null,
         "donate_url": null,
         "matrix_url": null,
-        "logo_source_url": null,
-        "logo_source_version": null
+        "logo_source_url": "https://cdn.jfksocial.com/static/logo.webp",
+        "logo_source_version": 1
     }
 ]

--- a/software.json
+++ b/software.json
@@ -1713,5 +1713,33 @@
         "matrix_url": null,
         "logo_source_url": "https://raw.githubusercontent.com/murlog-org/murlog/main/web/public/icon-512.png",
         "logo_source_version": 1
+    },
+    {
+        "name": "JFK Social",
+        "slug": "jfksocial",
+        "categories": [
+            "microblogging"
+        ],
+        "key_features": [
+            "Free speech / censorship-resistant social network",
+            "Nostr-based content with ActivityPub federation",
+            "Cross-network posting (Nostr, Mastodon, Bluesky)",
+            "Algorithmic and following feeds",
+            "Trust-based follow system",
+            "Premium accounts"
+        ],
+        "description": "A free-speech social network bridging Nostr and the fediverse via ActivityPub.",
+        "license": null,
+        "source_code": null,
+        "website": "https://jfksocial.com",
+        "apps_url": null,
+        "join_url": "https://jfksocial.com",
+        "api_docs_url": "https://api.jfksocial.com",
+        "support_url": null,
+        "forum_url": null,
+        "donate_url": null,
+        "matrix_url": null,
+        "logo_source_url": null,
+        "logo_source_version": null
     }
 ]


### PR DESCRIPTION
## Summary

Adds JFK Social to `software.json` and `apps.json`.

- **software.json**: `jfksocial` (microblogging). Slug matches the `software.name` served in our NodeInfo 2.0 document, so FediDB can link our servers to this entry.
- **apps.json**: JFK Social official web app.

## Software author permission

I am the maintainer of JFK Social and authorize this submission.

## Federation / NodeInfo

- Instance: https://jfksocial.com
- NodeInfo discovery: https://jfksocial.com/.well-known/nodeinfo
- NodeInfo 2.0: https://jfksocial.com/ap/nodeinfo/2.0 (`software.name = "jfksocial"`, `protocols: ["activitypub"]`)

## Notes

- `license`, `source_code`, and `logo_source_url` are currently null; will follow up with a hosted logo.